### PR TITLE
Refactor filter chips so that there are two rows and render all cards on initial load

### DIFF
--- a/src/Card.jsx
+++ b/src/Card.jsx
@@ -5,7 +5,7 @@ function Card ({selectedFilters, title, description, link, tags}) {
         return <li>{tag}</li>
     })
 
-    //Checks to see if a card's tag name is included in the selectedFilters array, if so returns true
+    //Checks to see if state is empty (if so, shows all cards) or if a card's tag name is included in state, if so returns true.
     const displayCard = selectedFilters.length === 0 || tags.some((tag) => selectedFilters.includes(tag));
 
 

--- a/src/Card.jsx
+++ b/src/Card.jsx
@@ -6,7 +6,7 @@ function Card ({selectedFilters, title, description, link, tags}) {
     })
 
     //Checks to see if a card's tag name is included in the selectedFilters array, if so returns true
-    const displayCard = tags.some((tag) => selectedFilters.includes(tag));
+    const displayCard = selectedFilters.length === 0 || tags.some((tag) => selectedFilters.includes(tag));
 
 
     if (!displayCard) {

--- a/src/Filters.jsx
+++ b/src/Filters.jsx
@@ -9,10 +9,6 @@ function Filters({data}) {
     'videos', 'voice', 'aphasia'];
 
 
-      const handleShowAll = () => {
-       setSelectedFilters(filtersArray);
-      }
-
       const handleReset = () => {
         return setSelectedFilters([]);
       }
@@ -51,8 +47,7 @@ function Filters({data}) {
                         <h4>Or filter by category:</h4>
                         
                         <div>
-                        <button onClick={handleShowAll}>Show All</button>
-                        <button onClick={handleReset}>Reset Filters</button>
+                        <button onClick={handleReset}>Clear Filters</button>
                         </div>
                         
                         

--- a/src/Filters.jsx
+++ b/src/Filters.jsx
@@ -50,7 +50,7 @@ function Filters({data}) {
                     <div className="">
                         <h4>Or filter by tags:</h4>
                         
-                        <div>
+                        <div className="filterdiv">
                         <h5>Therapy type:</h5>
                         {therapyFilters.map((selector) => (
                             <label key={selector} className={updateCheckedStyles(selector)}>
@@ -67,7 +67,7 @@ function Filters({data}) {
                         <button onClick={resetTherapyFilters}>Clear Filters</button>
                         </div>
 
-                        <div>
+                        <div className="filter-div">
                         <h5>Activity type:</h5>
                         {activityFilters.map((selector) => (
                             <label key={selector} className={updateCheckedStyles(selector)}>

--- a/src/Filters.jsx
+++ b/src/Filters.jsx
@@ -8,10 +8,14 @@ function Filters({data}) {
     const therapyFilters = ['fluency', 'pragmatics', 'language', 'articulation', 'voice', 'aphasia'];
     const activityFilters = ['games', 'expository text', 'videos', 'stories', 'science'];
 
+    //Keep only the selections that are not included in the specified array (group of tags)
+    const resetTherapyFilters = () => {
+      setSelectedFilters((prevState) => prevState.filter((selection) => !therapyFilters.includes(selection)))
+    }
 
-      const handleReset = () => {
-        return setSelectedFilters([]);
-      }
+    const resetActivityFilters = () => {
+      setSelectedFilters((prevState) => prevState.filter((selection) => !activityFilters.includes(selection)))
+    }
       
   
     const handleFilterSelection = (e) => {   
@@ -60,7 +64,7 @@ function Filters({data}) {
                             </label> 
 
                         ))}
-                        <button>Clear Filters</button>
+                        <button onClick={resetTherapyFilters}>Clear Filters</button>
                         </div>
 
                         <div>
@@ -77,10 +81,8 @@ function Filters({data}) {
                             </label> 
                             
                         ))}
-                        <button>Clear Filters</button>
+                        <button onClick={resetActivityFilters}>Clear Filters</button>
                         </div>
-                        
-                        
                         
                     </div>
 

--- a/src/Filters.jsx
+++ b/src/Filters.jsx
@@ -5,8 +5,8 @@ import Card from './Card';
 function Filters({data}) {
     const [selectedFilters, setSelectedFilters] = useState([]);
 
-    const filtersArray = ['games', 'fluency', 'pragmatics', 'stories', 'expository text', 'language', 'articulation', 'science', 
-    'videos', 'voice', 'aphasia'];
+    const therapyFilters = ['fluency', 'pragmatics', 'language', 'articulation', 'voice', 'aphasia'];
+    const activityFilters = ['games', 'expository text', 'videos', 'stories', 'science'];
 
 
       const handleReset = () => {
@@ -44,14 +44,11 @@ function Filters({data}) {
                     <input type="text" className="" placeholder="Search by name" />
                     
                     <div className="">
-                        <h4>Or filter by category:</h4>
+                        <h4>Or filter by tags:</h4>
                         
                         <div>
-                        <button onClick={handleReset}>Clear Filters</button>
-                        </div>
-                        
-                        
-                        {filtersArray.map((selector) => (
+                        <h5>Therapy type:</h5>
+                        {therapyFilters.map((selector) => (
                             <label key={selector} className={updateCheckedStyles(selector)}>
                                 {selector}
                                 <input 
@@ -63,8 +60,28 @@ function Filters({data}) {
                             </label> 
 
                         ))}
-                        
+                        <button>Clear Filters</button>
+                        </div>
 
+                        <div>
+                        <h5>Activity type:</h5>
+                        {activityFilters.map((selector) => (
+                            <label key={selector} className={updateCheckedStyles(selector)}>
+                                {selector}
+                                <input 
+                                  className="selector" 
+                                  name={selector} 
+                                  checked={selectedFilters.includes(selector)} 
+                                  type="checkbox" 
+                                  onChange={handleFilterSelection}/>
+                            </label> 
+                            
+                        ))}
+                        <button>Clear Filters</button>
+                        </div>
+                        
+                        
+                        
                     </div>
 
                 </div>

--- a/src/Filters.jsx
+++ b/src/Filters.jsx
@@ -36,9 +36,7 @@ function Filters({data}) {
       return selectedFilters.includes(selection) ? 'checked-styles' : 'unchecked-styles' ; 
     };
 
-
-
-    
+    //TODO: For UX, consider instead of "filter" terminology, use "search by tags" and "clear selection"
     return (
         <>
             <section className="resources">

--- a/src/Filters.jsx
+++ b/src/Filters.jsx
@@ -50,7 +50,7 @@ function Filters({data}) {
                     <div className="">
                         <h4>Or filter by tags:</h4>
                         
-                        <div className="filterdiv">
+                        <div className="filter-div">
                         <h5>Therapy type:</h5>
                         {therapyFilters.map((selector) => (
                             <label key={selector} className={updateCheckedStyles(selector)}>

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,10 @@ h1 {
   line-height: 1.1;
 }
 
+h5 {
+  margin: auto;
+}
+
 ul {
   list-style: none;
 }
@@ -56,7 +60,9 @@ ul {
 }
 
 /*Filter chips and tag styles*/
-
+.filter-div {
+  display: inline-flex;
+}
 
 label { /*Styles filter chips*/
   padding: 3px 6px;


### PR DESCRIPTION

## Description
This pull request refactors the filter chips so that there are separated into two categories: Therapy types and Activity types. The `filtersArray` was split up into two separate arrays and mapped over for each row. Each row has it's own `clear` button so that selections in the other row will still display. When both rows are cleared, all cards display. All cards display upon load and refresh as well. `Show all` button was removed. May consider bringing back for clarity to user.

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes #15 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|    | :sparkles: New feature     |
|   ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Notes
Consider changing terminology from "filters" to "selections" or "search by tags."



